### PR TITLE
Added map extension to NavigationController

### DIFF
--- a/FunctionalViewControllers/AppDelegate.swift
+++ b/FunctionalViewControllers/AppDelegate.swift
@@ -35,7 +35,7 @@ let chooseAlbum: ViewController<[Album],Album> = tableViewController { cell, alb
     return cell
 }
 
-let navigation = map(rootViewController(chooseArtist), { $0.albums }) >>> chooseAlbum
+let navigation = rootViewController(chooseArtist).map { $0.albums } >>> chooseAlbum
 
 
 @UIApplicationMain

--- a/FunctionalViewControllers/Library.swift
+++ b/FunctionalViewControllers/Library.swift
@@ -38,6 +38,16 @@ struct NavigationController<A,B> {
     let create: (A, (B, UINavigationController) -> ()) -> UINavigationController
 }
 
+extension NavigationController {
+    func map<C>(f: B -> C) -> NavigationController<A,C> {
+        return NavigationController<A, C> { x, callback in
+            return self.create(x) { (y, nc) in
+                callback(f(y), nc)
+            }
+        }
+    }
+}
+
 func run<A,B>(nc: NavigationController<A,B>, initialValue: A, finish: B -> ()) -> UINavigationController {
     return nc.create(initialValue) { b, _ in
         finish(b)


### PR DESCRIPTION
Really cool concept :)

I found the navigation setup hard to read because the map function interfered with the left -> right reading flow. By making it an extension on NavigationController, it reads much simpler.

I tried using the original map function inside of the extension (`return map(self, f)`), but that gave me strange compiler errors. Any clue why that might be?
